### PR TITLE
Draft:Check if pandoc and xetex are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Merge all Markdown files in a directory tree into a single PDF with formatting v
 
 ## Installation
 
+### Requirements
+The following applications must be available on `PATH`:
+- pandoc
+- xetex
+
 ### Install via pip
 
 ```sh

--- a/mdfusion/mdfusion.py
+++ b/mdfusion/mdfusion.py
@@ -227,6 +227,20 @@ def load_config_defaults(cfg_path: Path | None) -> dict:
     return manual_defaults
 
 
+def requirements_met() -> bool:
+    """Check if requirements are met."""
+    # shutil.which is a builtin cross-platform which utility
+    pandoc = shutil.which("pandoc")
+    xetex = shutil.which("xetex")
+
+    if not pandoc:
+        print("ERR: pandoc not found", file=sys.stderr)
+    if not xetex:
+        print("ERR: xetex not found", file=sys.stderr)
+
+    return bool(pandoc and xetex)
+
+
 def main():
     # 1) Find config file path
     cfg_path = None
@@ -272,7 +286,10 @@ def main():
     if not params.root_dir:
         parser.error("you must specify root_dir (or provide it in the config file)")
 
-    run(params)
+    if requirements_met():
+        run(params)
+    else:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Check if pandoc and xetex are available at runtime. Also, document requirements in README.md more clearly.

Should work on Linux and Windows, if Windows also uses pandoc and xetex commands. Sadly, I can't test on Windows. 
Do you have ideas how to write tests for that feature?